### PR TITLE
Add version constraints

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,12 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.0.0
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/ensureconda/api.py
+++ b/ensureconda/api.py
@@ -1,3 +1,5 @@
+import subprocess
+from distutils.version import LooseVersion
 from os import PathLike
 from typing import Optional
 
@@ -7,8 +9,30 @@ from ensureconda.resolve import (
     conda_standalone_executables,
     mamba_executables,
     micromamba_executables,
-    safe_next,
 )
+
+
+def determine_mamba_version(exe: PathLike) -> LooseVersion:
+    out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
+    for line in out.splitlines(keepends=False):
+        if line.startswith("mamba"):
+            return LooseVersion(line.split()[-1])
+    return LooseVersion("0.0.0")
+
+
+def determine_micromamba_version(exe: PathLike) -> LooseVersion:
+    out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
+    for line in out.splitlines(keepends=False):
+        return LooseVersion(line.split()[-1])
+    return LooseVersion("0.0.0")
+
+
+def determine_conda_version(exe: PathLike) -> LooseVersion:
+    out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
+    for line in out.splitlines(keepends=False):
+        if line.startswith("conda"):
+            return LooseVersion(line.split()[-1])
+    return LooseVersion("0.0.0")
 
 
 def ensureconda(
@@ -18,6 +42,8 @@ def ensureconda(
     conda: bool = True,
     conda_exe: bool = True,
     no_install: bool = False,
+    min_conda_version: Optional[LooseVersion] = None,
+    min_mamba_version: Optional[LooseVersion] = None,
 ) -> Optional[PathLike]:
     """Ensures that conda is installed
 
@@ -32,27 +58,43 @@ def ensureconda(
         Allow resolving conda.
     conda_exe
         Allow resolving conda-standalong
+    min_conda_version:
+        Minimum version of conda required
+    min_mamba_version:
+        Minimum version of mamba required
 
     Returns the path to a conda executable.
     """
     if mamba:
-        exe = safe_next(mamba_executables())
-        if exe:
-            return exe
+        for exe in mamba_executables():
+            if exe and (
+                (min_mamba_version is None)
+                or (determine_mamba_version(exe) >= min_mamba_version)
+            ):
+                return exe
     if micromamba:
-        exe = safe_next(micromamba_executables())
-        if exe:
-            return exe
+        for exe in micromamba_executables():
+            if exe and (
+                (min_mamba_version is None)
+                or (determine_micromamba_version(exe) >= min_mamba_version)
+            ):
+                return exe
         if not no_install:
             return install_micromamba()
     if conda:
-        exe = safe_next(conda_executables())
-        if exe:
-            return exe
+        for exe in conda_executables():
+            if exe and (
+                (min_conda_version is None)
+                or (determine_conda_version(exe) >= min_conda_version)
+            ):
+                return exe
     if conda_exe:
-        exe = safe_next(conda_standalone_executables())
-        if exe:
-            return exe
+        for exe in conda_standalone_executables():
+            if exe and (
+                (min_conda_version is None)
+                or (determine_conda_version(exe) >= min_conda_version)
+            ):
+                return exe
         if not no_install:
             return install_conda_exe()
     return None

--- a/ensureconda/cli.py
+++ b/ensureconda/cli.py
@@ -1,5 +1,6 @@
 import sys
 import time
+from distutils.version import LooseVersion
 
 import click
 
@@ -20,7 +21,17 @@ from ensureconda.api import ensureconda
     help="Search for conda.exe / conda-standalone, install if not present",
 )
 @click.option("--no-install", is_flag=True)
-def ensureconda_cli(mamba, micromamba, conda, conda_exe, no_install):
+@click.option("--min-conda-version", default=LooseVersion("4.8.2"), type=LooseVersion)
+@click.option("--min-mamba-version", default=LooseVersion("0.7.3"), type=LooseVersion)
+def ensureconda_cli(
+    mamba,
+    micromamba,
+    conda,
+    conda_exe,
+    no_install,
+    min_conda_version,
+    min_mamba_version,
+):
     # We run the loop twice, once to find all the eligible condas without installation
     # and once if you haven't found anything after installation
     exe = ensureconda(
@@ -29,6 +40,8 @@ def ensureconda_cli(mamba, micromamba, conda, conda_exe, no_install):
         conda=conda,
         conda_exe=conda_exe,
         no_install=True,
+        min_mamba_version=min_mamba_version,
+        min_conda_version=min_conda_version,
     )
     if not exe and not no_install:
         exe = ensureconda(
@@ -37,6 +50,8 @@ def ensureconda_cli(mamba, micromamba, conda, conda_exe, no_install):
             conda=conda,
             conda_exe=conda_exe,
             no_install=False,
+            min_mamba_version=min_mamba_version,
+            min_conda_version=min_conda_version,
         )
     if exe:
         print("Found compatible executable", file=sys.stderr, flush=True)

--- a/ensureconda/cli.py
+++ b/ensureconda/cli.py
@@ -1,10 +1,20 @@
 import sys
 import time
 from distutils.version import LooseVersion
+from typing import Union
 
 import click
 
 from ensureconda.api import ensureconda
+
+
+def _as_loose_version(obj: Union[str, LooseVersion, None]) -> LooseVersion:
+    if isinstance(obj, LooseVersion):
+        return obj
+    elif obj is None:
+        return LooseVersion("0.0.0")
+    else:
+        return LooseVersion(obj)
 
 
 @click.command(help="Ensures that a conda/mamba is installed.")
@@ -21,8 +31,12 @@ from ensureconda.api import ensureconda
     help="Search for conda.exe / conda-standalone, install if not present",
 )
 @click.option("--no-install", is_flag=True)
-@click.option("--min-conda-version", default=LooseVersion("4.8.2"), type=LooseVersion)
-@click.option("--min-mamba-version", default=LooseVersion("0.7.3"), type=LooseVersion)
+@click.option(
+    "--min-conda-version", default=LooseVersion("4.8.2"), type=_as_loose_version
+)
+@click.option(
+    "--min-mamba-version", default=LooseVersion("0.7.3"), type=_as_loose_version
+)
 def ensureconda_cli(
     mamba,
     micromamba,


### PR DESCRIPTION
This should prevent the situation where a very old conda executable is found that is
not capable of installing .conda archives

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
