### PR TITLE
Take conda_standalone from conda-forge channel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
             ENSURECONDA_EXE: ensureconda-darwin-amd64
           - os: windows-latest
             ENSURECONDA_EXE: ensureconda-windows-amd64.exe
+    env:
+      PYTHONUNBUFFERED: "1"
+      FORCE_COLOR: "1"
     steps:
       - uses: actions/checkout@v2
 
@@ -41,7 +44,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
-
+    env:
+      PYTHONUNBUFFERED: "1"
+      FORCE_COLOR: "1"
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .mypy_cache/
 .vscode/
 *.egg-info/
+.eggs/
 .tox/
 build/
 dist/

--- a/src/python/ensureconda/installer.py
+++ b/src/python/ensureconda/installer.py
@@ -51,7 +51,7 @@ def extract_files_from_conda_package(
 
 
 def install_conda_exe() -> Optional[Path]:
-    url = "https://api.anaconda.org/package/anaconda/conda-standalone/files"
+    url = "https://api.anaconda.org/package/conda-forge/conda-standalone/files"
     resp = request_url_with_retry(url)
     subdir = platform_subdir()
 

--- a/src/python/ensureconda/installer.py
+++ b/src/python/ensureconda/installer.py
@@ -51,14 +51,28 @@ def extract_files_from_conda_package(
 
 
 def install_conda_exe() -> Optional[Path]:
-    url = "https://api.anaconda.org/package/conda-forge/conda-standalone/files"
+    channel = "conda-forge"
+
+    url = "https://api.anaconda.org/package/{}/conda-standalone/files".format(channel)
     resp = request_url_with_retry(url)
     subdir = platform_subdir()
 
     candidates = []
     for file_info in resp.json():
         if file_info["attrs"]["subdir"] == subdir:
-            candidates.append(file_info["attrs"])
+            attrs = file_info["attrs"]
+            # the api for CDN backed channels like conda-forge differ from the one for anaconda so we need to fabricate some values
+            if "version" not in attrs:
+                attrs["version"] = file_info["version"]
+            if "source_url" not in attrs:
+                attrs["source_url"] = file_info["download_url"]
+                if not (
+                    attrs["source_url"].startswith("https://")
+                    or attrs["source_url"].startswith("http://")
+                ):
+                    attrs["source_url"] = "https://" + attrs["source_url"].lstrip("/")
+
+            candidates.append(attrs)
 
     candidates.sort(
         key=lambda attrs: (

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -2,12 +2,17 @@ import os
 import pathlib
 import subprocess
 import sys
+import typing
 
 from typing import List
 
 import docker
 import docker.models.containers
 import pytest
+
+
+if typing.TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
 
 
 @pytest.fixture(scope="session")
@@ -140,7 +145,7 @@ def test_ensure_full(
     _run_container_test(args, docker_client, expected, ensureconda_container_full)
 
 
-def test_locally_install(tmp_path, monkeypatch):
+def test_locally_install(tmp_path, monkeypatch: "MonkeyPatch"):
     # The order of these tests matter
     import appdirs
 
@@ -148,6 +153,7 @@ def test_locally_install(tmp_path, monkeypatch):
         return str(tmp_path)
 
     monkeypatch.setattr(appdirs, "user_data_dir", user_data_dir)
+    monkeypatch.delenv("CONDA_EXE", raising=False)
 
     from ensureconda.api import ensureconda
     from ensureconda.resolve import is_windows


### PR DESCRIPTION
I would like to use ensureconda with conda_standalone 4.10, but the default conda channel is (of course) outdated. It would be better to take it from the actively maintained conda-forge channel.