### PR TITLE
Switch from distutils LooseVersion to Version

### DIFF
--- a/news/packaging-version.md
+++ b/news/packaging-version.md
@@ -1,0 +1,3 @@
+### Fixed:
+
+* Fix DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "appdirs",
     "click>=5.1",
     "filelock",
+    "packaging",
     "requests>=2",
 ]
 dynamic = ["version"]

--- a/src/python/ensureconda/api.py
+++ b/src/python/ensureconda/api.py
@@ -1,7 +1,8 @@
 import subprocess
-from distutils.version import LooseVersion
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Optional
+
+from packaging.version import Version
 
 from ensureconda.installer import install_conda_exe, install_micromamba
 from ensureconda.resolve import (
@@ -15,27 +16,27 @@ if TYPE_CHECKING:
     from _typeshed import StrPath
 
 
-def determine_mamba_version(exe: "StrPath") -> LooseVersion:
+def determine_mamba_version(exe: "StrPath") -> Version:
     out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
     for line in out.splitlines(keepends=False):
         if line.startswith("mamba"):
-            return LooseVersion(line.split()[-1])
-    return LooseVersion("0.0.0")
+            return Version(line.split()[-1])
+    return Version("0.0.0")
 
 
-def determine_micromamba_version(exe: "StrPath") -> LooseVersion:
+def determine_micromamba_version(exe: "StrPath") -> Version:
     out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
     for line in out.splitlines(keepends=False):
-        return LooseVersion(line.split()[-1])
-    return LooseVersion("0.0.0")
+        return Version(line.split()[-1])
+    return Version("0.0.0")
 
 
-def determine_conda_version(exe: "StrPath") -> LooseVersion:
+def determine_conda_version(exe: "StrPath") -> Version:
     out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
     for line in out.splitlines(keepends=False):
         if line.startswith("conda"):
-            return LooseVersion(line.split()[-1])
-    return LooseVersion("0.0.0")
+            return Version(line.split()[-1])
+    return Version("0.0.0")
 
 
 def ensureconda(
@@ -45,8 +46,8 @@ def ensureconda(
     conda: bool = True,
     conda_exe: bool = True,
     no_install: bool = False,
-    min_conda_version: Optional[LooseVersion] = None,
-    min_mamba_version: Optional[LooseVersion] = None,
+    min_conda_version: Optional[Version] = None,
+    min_mamba_version: Optional[Version] = None,
 ) -> "Optional[StrPath]":
     """Ensures that conda is installed
 
@@ -71,8 +72,8 @@ def ensureconda(
 
     def version_constraint_met(
         executable: "StrPath",
-        min_version: Optional[LooseVersion],
-        version_fn: Callable[["StrPath"], LooseVersion],
+        min_version: Optional[Version],
+        version_fn: Callable[["StrPath"], Version],
     ) -> bool:
         return (min_version is None) or (version_fn(executable) >= min_version)
 

--- a/src/python/ensureconda/cli.py
+++ b/src/python/ensureconda/cli.py
@@ -1,20 +1,20 @@
 import sys
 import time
-from distutils.version import LooseVersion
 from typing import Any, Optional, Union
 
 import click
+from packaging.version import Version
 
 from ensureconda.api import ensureconda
 
 
-def _as_loose_version(obj: Union[str, LooseVersion, None]) -> LooseVersion:
-    if isinstance(obj, LooseVersion):
+def _as_loose_version(obj: Union[str, Version, None]) -> Version:
+    if isinstance(obj, Version):
         return obj
     elif obj is None:
-        return LooseVersion("0.0.0")
+        return Version("0.0.0")
     else:
-        return LooseVersion(obj)
+        return Version(obj)
 
 
 _DEFAULT_MIN_CONDA = "4.8.2"
@@ -25,8 +25,8 @@ class VersionNumber(click.ParamType):
     name = "VersionNumber"
 
     def convert(
-        self, value: Union[str, LooseVersion, None], param: Any, ctx: Any
-    ) -> LooseVersion:
+        self, value: Union[str, Version, None], param: Any, ctx: Any
+    ) -> Version:
         return _as_loose_version(value)
 
 
@@ -50,13 +50,13 @@ class VersionNumber(click.ParamType):
 )
 @click.option(
     "--min-conda-version",
-    default=LooseVersion(_DEFAULT_MIN_CONDA),
+    default=Version(_DEFAULT_MIN_CONDA),
     type=VersionNumber(),
     help=f"minimum version of conda to accept (defaults to {_DEFAULT_MIN_CONDA})",
 )
 @click.option(
     "--min-mamba-version",
-    default=LooseVersion(_DEFAULT_MIN_MAMBA),
+    default=Version(_DEFAULT_MIN_MAMBA),
     type=VersionNumber(),
     help=f"minimum version of mamba/micromamba to accept (defaults to {_DEFAULT_MIN_MAMBA})",
 )
@@ -66,8 +66,8 @@ def ensureconda_cli(
     conda: bool,
     conda_exe: bool,
     no_install: bool,
-    min_conda_version: Optional[LooseVersion],
-    min_mamba_version: Optional[LooseVersion],
+    min_conda_version: Optional[Version],
+    min_mamba_version: Optional[Version],
 ) -> None:
     # We run the loop twice, once to find all the eligible condas without installation
     # and once if you haven't found anything after installation

--- a/src/python/ensureconda/installer.py
+++ b/src/python/ensureconda/installer.py
@@ -6,12 +6,12 @@ import stat
 import tarfile
 import time
 import uuid
-from distutils.version import LooseVersion
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Iterator, Optional
 
 import filelock
 import requests
+from packaging.version import Version
 
 from ensureconda.resolve import is_windows, platform_subdir, site_path
 
@@ -64,7 +64,7 @@ def install_conda_exe() -> Optional[Path]:
 
     candidates.sort(
         key=lambda attrs: (
-            LooseVersion(attrs["version"]),
+            Version(attrs["version"]),
             attrs["build_number"],
             attrs["timestamp"],
         )


### PR DESCRIPTION
Fix DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
