### PR TITLE
Install `conda-standalone` from conda-forge instead of Anaconda channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Options:
 
 When ensureconda downloads the conda-standalone executable, you can select the
 channel via the environment variable `ENSURECONDA_CONDA_STANDALONE_CHANNEL`.
-It defaults to `anaconda`, and you can set it to `conda-forge` if you prefer:
+It defaults to `conda-forge`, and you can set it to `anaconda` if you prefer:
 
 ```bash
-export ENSURECONDA_CONDA_STANDALONE_CHANNEL=conda-forge
+export ENSURECONDA_CONDA_STANDALONE_CHANNEL=anaconda
 ensureconda --conda-exe
 ```
 

--- a/src/golang/cmd/install.go
+++ b/src/golang/cmd/install.go
@@ -101,7 +101,7 @@ func (a AnacondaPkgs) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func getChannelName() (string, error) {
 	channel := os.Getenv("ENSURECONDA_CONDA_STANDALONE_CHANNEL")
 	if channel == "" {
-		channel = "anaconda"
+		channel = "conda-forge"
 	}
 	validChannelName := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 	if !validChannelName.MatchString(channel) {

--- a/src/python/ensureconda/installer.py
+++ b/src/python/ensureconda/installer.py
@@ -164,7 +164,7 @@ def stream_conda_executable(url: str) -> Path:
 
 
 def get_channel_name() -> str:
-    channel = os.environ.get("ENSURECONDA_CONDA_STANDALONE_CHANNEL", "anaconda")
+    channel = os.environ.get("ENSURECONDA_CONDA_STANDALONE_CHANNEL", "conda-forge")
     # Raise an error if the channel name contains any non-alphanumeric characters
     # besides - or _
     if not channel.replace("-", "").replace("_", "").isalnum():


### PR DESCRIPTION
With the latest version installed from Anaconda I get this error:

(I encountered this via `conda-lock` who installed and ran `ensure-conda` for me) 
```
mambauser ➜ /workspaces/env (main ✗) $ /home/mambauser/.local/share/ensure-conda/conda_standalone --version

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "conda/exception_handler.py", line 17, in __call__
      File "conda/cli/main.py", line 73, in main_subshell
      File "conda/cli/conda_argparse.py", line 124, in generate_parser
      File "conda/cli/conda_argparse.py", line 352, in configure_parser_plugins
      File "conda/cli/find_commands.py", line 54, in find_commands
      File "conda/cli/find_commands.py", line 54, in <listcomp>
      File "sysconfig.py", line 532, in get_path
      File "sysconfig.py", line 522, in get_paths
      File "sysconfig.py", line 175, in _expand_vars
      File "sysconfig.py", line 572, in get_config_vars
      File "sysconfig.py", line 438, in _init_posix
    ModuleNotFoundError: No module named '_sysconfigdata_x86_64_conda_cos6_linux_gnu'

`$ /home/mambauser/.local/share/ensure-conda/conda_standalone --version`

  environment variables:
                 CIO_TEST=<not set>
        CMAKE_PREFIX_PATH=/opt/conda:/opt/conda/x86_64-conda-linux-gnu/sysroot/usr
      CONDA_BUILD_SYSROOT=/opt/conda/x86_64-conda-linux-gnu/sysroot
        CONDA_DEFAULT_ENV=base
             CONDA_PREFIX=/opt/conda
    CONDA_PROMPT_MODIFIER=(base)
               CONDA_ROOT=/tmp/_MEIYFuu5Y
              CONDA_SHLVL=1
    CONDA_TOOLCHAIN_BUILD=x86_64-conda-linux-gnu
     CONDA_TOOLCHAIN_HOST=x86_64-conda-linux-gnu
           CURL_CA_BUNDLE=<not set>
          LD_LIBRARY_PATH=/tmp/_MEIYFuu5Y:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
               LD_PRELOAD=<not set>
                     PATH=/opt/conda/bin:/vscode/vscode-server/bin/linux-x64/8b3775030ed1a69b13e
                          4f4c628c612102e30a681/bin/remote-cli:/opt/conda/condabin:/usr/local/nv
                          idia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:
                          /usr/bin:/sbin:/bin:/home/mambauser/.local/bin
       REQUESTS_CA_BUNDLE=<not set>
            SSL_CERT_FILE=<not set>

     active environment : /opt/conda
    active env location : /opt/conda
            shell level : 1
       user config file : /home/mambauser/.condarc
 populated config files : /home/mambauser/.condarc
          conda version : 23.10.0
    conda-build version : not installed
         python version : 3.9.18.final.0
       virtual packages : __archspec=1=zen3
                          __cuda=12.0=0
                          __glibc=2.35=0
                          __linux=5.4.0=0
                          __unix=0=0
       base environment : /tmp/_MEIYFuu5Y  (read only)
      conda av data dir : /tmp/_MEIYFuu5Y/etc/conda
  conda av metadata url : None
           channel URLs : https://conda.anaconda.org/conda-forge/linux-64
                          https://conda.anaconda.org/conda-forge/noarch
          package cache : /tmp/_MEIYFuu5Y/pkgs
                          /home/mambauser/.conda/pkgs
       envs directories : /home/mambauser/.conda/envs
                          /tmp/_MEIYFuu5Y/envs
               platform : linux-64
             user-agent : conda/23.10.0 requests/2.31.0 CPython/3.9.18 Linux/5.4.0-146-generic ubuntu/22.04.3 glibc/2.35 solver/libmamba conda-libmamba-solver/23.12.0 libmambapy/1.5.3
                UID:GID : 1022:1022
             netrc file : None
           offline mode : False


An unexpected error has occurred. Conda has prepared the above report.
If you suspect this error is being caused by a malfunctioning plugin,
consider using the --no-plugins option to turn off plugins.

Example: conda --no-plugins install <package>

Alternatively, you can set the CONDA_NO_PLUGINS environment variable on
the command line to run the command without plugins enabled.

Example: CONDA_NO_PLUGINS=true conda install <package>

If submitted, this report will be used by core maintainers to improve
future releases of conda.
Would you like conda to send this report to the core maintainers? [y/N]: 
```

Installing it from conda-forge solves the issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
