### PR TITLE
Delete CONDA_EXE in test when running locally

### DIFF
--- a/test/test_library.py
+++ b/test/test_library.py
@@ -151,6 +151,7 @@ def test_locally_install(tmp_path, monkeypatch):
     from ensureconda.api import ensureconda
     from ensureconda.resolve import is_windows
 
+    monkeypatch.delenv("CONDA_EXE", raising=False)
     # remove all paths from $PATH until we don't have a conda executable
     conda_executable = ensureconda(no_install=True)
     while conda_executable is not None:


### PR DESCRIPTION
Otherwise if there is a conda executable defined by `CONDA_EXE` it will lead to an error when trying to remove it from the path.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Added a ``news`` entry

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
