### PR TITLE
Handle mamba v2

### DIFF
--- a/src/golang/cmd/resolve.go
+++ b/src/golang/cmd/resolve.go
@@ -46,7 +46,7 @@ func ResolveExecutable(executableName string, dataDir string, versionPredicate f
 			filteredPaths = append(filteredPaths, dir)
 		}
 	}
-	newPathEnv := filepath.Join(filteredPaths...)
+	newPathEnv := strings.Join(filteredPaths, string(os.PathListSeparator))
 	return FindExecutable(executableName, newPathEnv, versionPredicate)
 }
 

--- a/src/python/ensureconda/api.py
+++ b/src/python/ensureconda/api.py
@@ -17,11 +17,25 @@ if TYPE_CHECKING:
 
 
 def determine_mamba_version(exe: "StrPath") -> Version:
+    """Determine the version of mamba on the given executable.
+
+    Typical output of `mamba --version` for v1 is:
+    ```
+    mamba 1.4.7
+    conda 23.5.0
+    ```
+
+    Typical output of `mamba --version` for v2 is identical to micromamba:
+    ```
+    2.0.8
+    ```
+    """
     out = subprocess.check_output([exe, "--version"], encoding="utf-8").strip()
     for line in out.splitlines(keepends=False):
         if line.startswith("mamba"):
             return Version(line.split()[-1])
-    return Version("0.0.0")
+    # Not v1 style output, so fall back to micromamba version detection
+    return determine_micromamba_version(exe)
 
 
 def determine_micromamba_version(exe: "StrPath") -> Version:

--- a/test/docker-full/Dockerfile
+++ b/test/docker-full/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda3:latest
 
-RUN conda install -c conda-forge "mamba<2"
+RUN conda install -c conda-forge mamba
 
 WORKDIR /tmp
 ADD . /tmp


### PR DESCRIPTION
Typical output of `mamba --version` for v1 is:
```
mamba 1.4.7
conda 23.5.0
```

Typical output of `mamba --version` for v2 doesn't include `mamba`/`conda` prefixes, identical to micromamba:
```
2.0.8
```
