### PR TITLE
Fix concurrency problem with downloading file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         pixi-env: ["test-py38", "test-py313"]
+    defaults:
+      run:
+        shell: bash -eo pipefail -l {0}
 
     steps:
       - uses: actions/checkout@v4
@@ -53,20 +56,20 @@ jobs:
       - uses: prefix-dev/setup-pixi@v0.8.3
         with:
           environments: ${{ matrix.pixi-env }}
+          activate-environment: true
 
       - name: Lint with flake8
-        shell: bash  # Necessary for using '\' as line continuation
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          pixi run -e ${{ matrix.pixi-env }} flake8 . --count --select=E9,F63,F7,F82 \
+          flake8 . --count --select=E9,F63,F7,F82 \
                           --show-source --statistics
 
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          pixi run -e ${{ matrix.pixi-env }} flake8 . --count --exit-zero \
+          flake8 . --count --exit-zero \
                           --max-complexity=10 --max-line-length=127 --statistics
 
       - name: Run tests
         run: |
-          pixi run -e ${{ matrix.pixi-env }} coverage run --parallel-mode -m pytest -vv
-          pixi run -e ${{ matrix.pixi-env }} coverage combine --append
-          pixi run -e ${{ matrix.pixi-env }} coverage report -m
+          coverage run --parallel-mode -m pytest -vv
+          coverage combine --append
+          coverage report -m

--- a/pixi.lock
+++ b/pixi.lock
@@ -1648,8 +1648,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -1921,8 +1919,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - libbrotlicommon 1.1.0 h00291cd_2
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -2190,8 +2186,6 @@ packages:
   - pycparser
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -2402,8 +2396,6 @@ packages:
   - python >=3.8,<3.9.0a0
   - python_abi 3.8.* *_cp38
   - tomli
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2419,8 +2411,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tomli
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2436,8 +2426,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - tomli
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2452,8 +2440,6 @@ packages:
   - python >=3.8,<3.9.0a0
   - python_abi 3.8.* *_cp38
   - tomli
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2468,8 +2454,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tomli
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2484,8 +2468,6 @@ packages:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - tomli
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2501,8 +2483,6 @@ packages:
   - python >=3.8,<3.9.0a0 *_cpython
   - python_abi 3.8.* *_cp38
   - tomli
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2518,8 +2498,6 @@ packages:
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
   - tomli
-  arch: arm64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2536,8 +2514,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2554,8 +2530,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   purls:
@@ -2644,8 +2618,6 @@ packages:
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=10.13
-  arch: x86_64
-  platform: osx
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
@@ -2795,8 +2767,8 @@ packages:
   timestamp: 1734056379149
 - pypi: .
   name: ensureconda
-  version: 1.4.5.dev36+g3246402.d20250402
-  sha256: c36817f1b8ff8b7bb418942339de1b239c92fdffac5111d08d5b67cea4bc6895
+  version: 1.4.5.dev45+g347aa56.d20250402
+  sha256: a107262abe4a2af4367cc35794b047af553a35f855a0c89914528789159d1d88
   requires_dist:
   - appdirs
   - click>=5.1
@@ -3662,8 +3634,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - typing_extensions >=4.1.0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -4115,8 +4085,6 @@ packages:
   - __osx >=10.13
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls:
@@ -4320,8 +4288,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - six
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   purls:
@@ -4639,8 +4605,6 @@ packages:
   - tzdata
   constrains:
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: Python-2.0
   purls: []
   size: 13833024
@@ -4855,8 +4819,6 @@ packages:
   md5: e6096b1328952bbe07342f8927940ea9
   constrains:
   - python 3.12.* *_cpython
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls: []
@@ -5033,8 +4995,6 @@ packages:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -5462,8 +5422,6 @@ packages:
   - libcxx >=17
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   purls:
@@ -5962,8 +5920,6 @@ packages:
   - cffi >=1.11
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   purls:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ packages = ["src/python/ensureconda"]
 [tool.pytest]
 flake8-max-line-length = 105
 flake8-ignore = ["docs/*", "ALL"]
+addopts = "-vvv"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Establishes a lock for downloading a conda/micromamba executable.

This is particularly crucial on Windows where concurrent downloads will fail when attempting to replace an in-use executable.