### PR TITLE
filter out `_onedir_` variants as workaround for conda/conda-standalone#182

### DIFF
--- a/src/golang/cmd/install.go
+++ b/src/golang/cmd/install.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 
@@ -105,7 +106,10 @@ func InstallCondaStandalone() (string, error) {
 
 	var candidates = make([]AnacondaPkgAttr, 0)
 	for _, datum := range data {
-		if datum.Attrs.Subdir == subdir {
+		if datum.Attrs.Subdir == subdir &&
+			// Ignore onedir packages as workaround for
+			// <https://github.com/conda/conda-standalone/issues/182>
+			!strings.Contains(datum.Attrs.SourceUrl, "_onedir_") {
 			candidates = append(candidates, datum.Attrs)
 		}
 	}

--- a/src/python/ensureconda/installer.py
+++ b/src/python/ensureconda/installer.py
@@ -135,7 +135,13 @@ def install_conda_exe() -> Optional[Path]:
 
         candidates = []
         for file_info in resp.json():
-            if file_info["attrs"]["subdir"] == subdir:
+            if (
+                file_info["attrs"]["subdir"] == subdir
+                and
+                # Ignore onedir packages as workaround for
+                # <https://github.com/conda/conda-standalone/issues/182>
+                "_onedir_" not in file_info["attrs"]["source_url"]
+            ):
                 candidates.append(file_info["attrs"])
 
         candidates.sort(


### PR DESCRIPTION
Addresses conda/conda-standalone#182